### PR TITLE
fix panic when setting rate to lower than tokens consumed last interval

### DIFF
--- a/bucket.go
+++ b/bucket.go
@@ -127,5 +127,6 @@ func (b *bucket) drain(wait bool) {
 func (b *bucket) setRate(opts RateOpts) {
 	b.l.Lock()
 	b.opts = opts
+	b.drained = time.Now().Add(-b.opts.Interval)
 	b.l.Unlock()
 }


### PR DESCRIPTION
fixes this by restarting interval when setting rate

#2 